### PR TITLE
Improve stake sync process

### DIFF
--- a/contracts/child/ChildValidatorSet.sol
+++ b/contracts/child/ChildValidatorSet.sol
@@ -19,7 +19,6 @@ import "./h_modules/ExtendedDelegation.sol";
 import "./h_modules/ExtendedStaking.sol";
 import "./h_modules/VestManager.sol";
 import "./h_modules/Vesting.sol";
-import "./h_modules/StakeSyncer.sol";
 
 import "../libs/ValidatorStorage.sol";
 import "../libs/ValidatorQueue.sol";
@@ -41,7 +40,6 @@ contract ChildValidatorSet is
     CVSAccessControl,
     CVSWithdrawal,
     PowerExponent,
-    StakeSyncer,
     CVSDelegation,
     ExtendedStaking,
     ExtendedDelegation
@@ -296,13 +294,6 @@ contract ChildValidatorSet is
             validator.stake = (int256(validator.stake) + item.stake).toUint256Safe();
             _validators.insert(validatorAddr, validator);
             _queue.resetIndex(validatorAddr);
-
-            // H_MODIFY: Sync stake change with the node
-            if (item.stake > 0) {
-                _syncStake(validatorAddr, uint256(item.stake));
-            } else if (item.stake < 0) {
-                _syncUnstake(validatorAddr, uint256(item.stake * -1));
-            }
         }
         _queue.reset();
     }

--- a/contracts/child/h_modules/ExtendedStaking.sol
+++ b/contracts/child/h_modules/ExtendedStaking.sol
@@ -47,6 +47,7 @@ abstract contract ExtendedStaking is StakerVesting, CVSStaking {
         claimValidatorReward();
 
         _queue.insert(msg.sender, amountInt * -1, 0);
+        _syncUnstake(msg.sender, amount);
         if (amountAfterUnstake == 0) {
             _validators.get(msg.sender).active = false;
         }

--- a/contracts/child/modules/CVSStaking.sol
+++ b/contracts/child/modules/CVSStaking.sol
@@ -9,12 +9,13 @@ import "../../interfaces/Errors.sol";
 import "../../interfaces/modules/ICVSStaking.sol";
 
 import "./../h_modules/Vesting.sol";
+import "../h_modules/StakeSyncer.sol";
 
 import "../../libs/ValidatorStorage.sol";
 import "../../libs/ValidatorQueue.sol";
 import "../../libs/SafeMathInt.sol";
 
-abstract contract CVSStaking is ICVSStaking, CVSStorage, CVSAccessControl, CVSWithdrawal {
+abstract contract CVSStaking is ICVSStaking, CVSStorage, CVSAccessControl, CVSWithdrawal, StakeSyncer {
     using ValidatorStorageLib for ValidatorTree;
     using ValidatorQueueLib for ValidatorQueue;
     using SafeMathUint for uint256;
@@ -50,6 +51,7 @@ abstract contract CVSStaking is ICVSStaking, CVSStorage, CVSAccessControl, CVSWi
             revert StakeRequirement({src: "stake", msg: "STAKE_TOO_LOW"});
         claimValidatorReward();
         _queue.insert(msg.sender, int256(msg.value), 0);
+        _syncStake(msg.sender, msg.value);
         emit Staked(msg.sender, msg.value);
     }
 

--- a/docs/child/ChildValidatorSet.md
+++ b/docs/child/ChildValidatorSet.md
@@ -924,6 +924,28 @@ Gets validator&#39;s unclaimed rewards.
 |---|---|---|
 | _0 | uint256 | Validator&#39;s unclaimed rewards (in MATIC wei) |
 
+### getValidatorTotalStake
+
+```solidity
+function getValidatorTotalStake(address validator) external view returns (uint256)
+```
+
+A function to return the total stake together with the pending stake H_MODIFY: Temporary fix to address the new way the node fetches the validators state It checks for transfer events and sync the stake change with the node But a check is made after every block and the changes are applied from the next epoch Also it doesn&#39;t update the balance of the validator based on the amount emmited in the event but fetches the balance from the contract. That&#39;s why we apply the pending balance here
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### getVestingBonus
 
 ```solidity

--- a/docs/child/h_modules/DelegationVesting.md
+++ b/docs/child/h_modules/DelegationVesting.md
@@ -507,6 +507,28 @@ Gets validator by address.
 | withdrawableRewards | uint256 | withdrawable rewards |
 | active | bool | activity status |
 
+### getValidatorTotalStake
+
+```solidity
+function getValidatorTotalStake(address validator) external view returns (uint256)
+```
+
+A function to return the total stake together with the pending stake H_MODIFY: Temporary fix to address the new way the node fetches the validators state It checks for transfer events and sync the stake change with the node But a check is made after every block and the changes are applied from the next epoch Also it doesn&#39;t update the balance of the validator based on the amount emmited in the event but fetches the balance from the contract. That&#39;s why we apply the pending balance here
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### getVestingBonus
 
 ```solidity

--- a/docs/child/h_modules/ExtendedDelegation.md
+++ b/docs/child/h_modules/ExtendedDelegation.md
@@ -587,6 +587,28 @@ Gets validator by address.
 | withdrawableRewards | uint256 | withdrawable rewards |
 | active | bool | activity status |
 
+### getValidatorTotalStake
+
+```solidity
+function getValidatorTotalStake(address validator) external view returns (uint256)
+```
+
+A function to return the total stake together with the pending stake H_MODIFY: Temporary fix to address the new way the node fetches the validators state It checks for transfer events and sync the stake change with the node But a check is made after every block and the changes are applied from the next epoch Also it doesn&#39;t update the balance of the validator based on the amount emmited in the event but fetches the balance from the contract. That&#39;s why we apply the pending balance here
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### getVestingBonus
 
 ```solidity

--- a/docs/child/h_modules/ExtendedStaking.md
+++ b/docs/child/h_modules/ExtendedStaking.md
@@ -477,6 +477,28 @@ Gets validator&#39;s unclaimed rewards.
 |---|---|---|
 | _0 | uint256 | Validator&#39;s unclaimed rewards (in MATIC wei) |
 
+### getValidatorTotalStake
+
+```solidity
+function getValidatorTotalStake(address validator) external view returns (uint256)
+```
+
+A function to return the total stake together with the pending stake H_MODIFY: Temporary fix to address the new way the node fetches the validators state It checks for transfer events and sync the stake change with the node But a check is made after every block and the changes are applied from the next epoch Also it doesn&#39;t update the balance of the validator based on the amount emmited in the event but fetches the balance from the contract. That&#39;s why we apply the pending balance here
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### getVestingBonus
 
 ```solidity
@@ -1119,6 +1141,24 @@ event Staked(address indexed validator, uint256 amount)
 |---|---|---|
 | validator `indexed` | address | undefined |
 | amount  | uint256 | undefined |
+
+### Transfer
+
+```solidity
+event Transfer(address indexed from, address indexed to, uint256 value)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from `indexed` | address | undefined |
+| to `indexed` | address | undefined |
+| value  | uint256 | undefined |
 
 ### Unstaked
 

--- a/docs/child/h_modules/PowerExponent.md
+++ b/docs/child/h_modules/PowerExponent.md
@@ -264,6 +264,28 @@ Gets validator by address.
 | withdrawableRewards | uint256 | withdrawable rewards |
 | active | bool | activity status |
 
+### getValidatorTotalStake
+
+```solidity
+function getValidatorTotalStake(address validator) external view returns (uint256)
+```
+
+A function to return the total stake together with the pending stake H_MODIFY: Temporary fix to address the new way the node fetches the validators state It checks for transfer events and sync the stake change with the node But a check is made after every block and the changes are applied from the next epoch Also it doesn&#39;t update the balance of the validator based on the amount emmited in the event but fetches the balance from the contract. That&#39;s why we apply the pending balance here
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### implementation
 
 ```solidity

--- a/docs/child/h_modules/StakeSyncer.md
+++ b/docs/child/h_modules/StakeSyncer.md
@@ -4,7 +4,7 @@
 
 > StakeSyncer
 
-This contract is used to emit a specific event on stake, unstake, delegate and udelegate; Child chain listen for this event to sync the state of the validators
+This contract is used to emit a specific event on stake, unstake, delegate and undelegate; Child chain listen for this event to sync the state of the validators
 
 
 

--- a/docs/child/h_modules/StakerVesting.md
+++ b/docs/child/h_modules/StakerVesting.md
@@ -401,6 +401,28 @@ Gets validator by address.
 | withdrawableRewards | uint256 | withdrawable rewards |
 | active | bool | activity status |
 
+### getValidatorTotalStake
+
+```solidity
+function getValidatorTotalStake(address validator) external view returns (uint256)
+```
+
+A function to return the total stake together with the pending stake H_MODIFY: Temporary fix to address the new way the node fetches the validators state It checks for transfer events and sync the stake change with the node But a check is made after every block and the changes are applied from the next epoch Also it doesn&#39;t update the balance of the validator based on the amount emmited in the event but fetches the balance from the contract. That&#39;s why we apply the pending balance here
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### getVestingBonus
 
 ```solidity

--- a/docs/child/h_modules/VestFactory.md
+++ b/docs/child/h_modules/VestFactory.md
@@ -219,6 +219,28 @@ Gets validator by address.
 | withdrawableRewards | uint256 | withdrawable rewards |
 | active | bool | activity status |
 
+### getValidatorTotalStake
+
+```solidity
+function getValidatorTotalStake(address validator) external view returns (uint256)
+```
+
+A function to return the total stake together with the pending stake H_MODIFY: Temporary fix to address the new way the node fetches the validators state It checks for transfer events and sync the stake change with the node But a check is made after every block and the changes are applied from the next epoch Also it doesn&#39;t update the balance of the validator based on the amount emmited in the event but fetches the balance from the contract. That&#39;s why we apply the pending balance here
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### implementation
 
 ```solidity

--- a/docs/child/modules/CVSAccessControl.md
+++ b/docs/child/modules/CVSAccessControl.md
@@ -246,6 +246,28 @@ Gets validator by address.
 | withdrawableRewards | uint256 | withdrawable rewards |
 | active | bool | activity status |
 
+### getValidatorTotalStake
+
+```solidity
+function getValidatorTotalStake(address validator) external view returns (uint256)
+```
+
+A function to return the total stake together with the pending stake H_MODIFY: Temporary fix to address the new way the node fetches the validators state It checks for transfer events and sync the stake change with the node But a check is made after every block and the changes are applied from the next epoch Also it doesn&#39;t update the balance of the validator based on the amount emmited in the event but fetches the balance from the contract. That&#39;s why we apply the pending balance here
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### implementation
 
 ```solidity

--- a/docs/child/modules/CVSDelegation.md
+++ b/docs/child/modules/CVSDelegation.md
@@ -459,6 +459,28 @@ Gets validator by address.
 | withdrawableRewards | uint256 | withdrawable rewards |
 | active | bool | activity status |
 
+### getValidatorTotalStake
+
+```solidity
+function getValidatorTotalStake(address validator) external view returns (uint256)
+```
+
+A function to return the total stake together with the pending stake H_MODIFY: Temporary fix to address the new way the node fetches the validators state It checks for transfer events and sync the stake change with the node But a check is made after every block and the changes are applied from the next epoch Also it doesn&#39;t update the balance of the validator based on the amount emmited in the event but fetches the balance from the contract. That&#39;s why we apply the pending balance here
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### getVestingBonus
 
 ```solidity

--- a/docs/child/modules/CVSStaking.md
+++ b/docs/child/modules/CVSStaking.md
@@ -279,6 +279,28 @@ Gets validator&#39;s unclaimed rewards.
 |---|---|---|
 | _0 | uint256 | Validator&#39;s unclaimed rewards (in MATIC wei) |
 
+### getValidatorTotalStake
+
+```solidity
+function getValidatorTotalStake(address validator) external view returns (uint256)
+```
+
+A function to return the total stake together with the pending stake H_MODIFY: Temporary fix to address the new way the node fetches the validators state It checks for transfer events and sync the stake change with the node But a check is made after every block and the changes are applied from the next epoch Also it doesn&#39;t update the balance of the validator based on the amount emmited in the event but fetches the balance from the contract. That&#39;s why we apply the pending balance here
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### implementation
 
 ```solidity
@@ -765,6 +787,24 @@ event Staked(address indexed validator, uint256 amount)
 |---|---|---|
 | validator `indexed` | address | undefined |
 | amount  | uint256 | undefined |
+
+### Transfer
+
+```solidity
+event Transfer(address indexed from, address indexed to, uint256 value)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from `indexed` | address | undefined |
+| to `indexed` | address | undefined |
+| value  | uint256 | undefined |
 
 ### Unstaked
 

--- a/docs/child/modules/CVSStorage.md
+++ b/docs/child/modules/CVSStorage.md
@@ -219,6 +219,28 @@ Gets validator by address.
 | withdrawableRewards | uint256 | withdrawable rewards |
 | active | bool | activity status |
 
+### getValidatorTotalStake
+
+```solidity
+function getValidatorTotalStake(address validator) external view returns (uint256)
+```
+
+A function to return the total stake together with the pending stake H_MODIFY: Temporary fix to address the new way the node fetches the validators state It checks for transfer events and sync the stake change with the node But a check is made after every block and the changes are applied from the next epoch Also it doesn&#39;t update the balance of the validator based on the amount emmited in the event but fetches the balance from the contract. That&#39;s why we apply the pending balance here
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### implementation
 
 ```solidity

--- a/docs/child/modules/CVSWithdrawal.md
+++ b/docs/child/modules/CVSWithdrawal.md
@@ -219,6 +219,28 @@ Gets validator by address.
 | withdrawableRewards | uint256 | withdrawable rewards |
 | active | bool | activity status |
 
+### getValidatorTotalStake
+
+```solidity
+function getValidatorTotalStake(address validator) external view returns (uint256)
+```
+
+A function to return the total stake together with the pending stake H_MODIFY: Temporary fix to address the new way the node fetches the validators state It checks for transfer events and sync the stake change with the node But a check is made after every block and the changes are applied from the next epoch Also it doesn&#39;t update the balance of the validator based on the amount emmited in the event but fetches the balance from the contract. That&#39;s why we apply the pending balance here
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| validator | address | Address of the validator |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### implementation
 
 ```solidity


### PR DESCRIPTION
Emit events exactly when the change occurs (not at the end of the epoch)
Return the total stake together with the pending one to overcome the obstacle in the node implementation